### PR TITLE
Fix Service export for ExternalName

### DIFF
--- a/files/project_export.sh
+++ b/files/project_export.sh
@@ -193,15 +193,19 @@ svcs(){
             .metadata.generation,
             .spec.clusterIP
             )' > ${PROJECT}/svc_${svc}.json
+    # If no app selector is present AND the service type is NOT ExternalName,
+    # backup the explicit endpoint configuration as well.
     if [[ $(cat ${PROJECT}/svc_${svc}.json | jq -e '.spec.selector.app') == "null" ]]; then
-      oc get --export -o json endpoints ${svc} -n ${PROJECT}| jq '
-        del(.status,
-            .metadata.uid,
-            .metadata.selfLink,
-            .metadata.resourceVersion,
-            .metadata.creationTimestamp,
-            .metadata.generation
-            )' > ${PROJECT}/endpoint_${svc}.json
+      if [[ $(cat ${PROJECT}/svc_${svc}.json | jq -re '.spec.type') != "ExternalName" ]]; then
+        oc get --export -o json endpoints ${svc} -n ${PROJECT}| jq '
+          del(.status,
+              .metadata.uid,
+              .metadata.selfLink,
+              .metadata.resourceVersion,
+              .metadata.creationTimestamp,
+              .metadata.generation
+              )' > ${PROJECT}/endpoint_${svc}.json
+      fi
     fi
   done
 }


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
When exporting a Service resource, the backup script checks a service's app selectors, and, if absent, attempts to export the explicitly created Endpoint resource as well.

However, if the Service is of type ExternalName, there is no selector, but also no Endpoint resource, as documented [here][k8s-doc].

This PR takes this into consideration, by only attempting to export the Endpoint resource, if the Service type is not ExternalName.

##### ISSUE TYPE
 - Bugfix Pull Request

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.8.4
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['~/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python3.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 3.7.4 (default, Jul 16 2019, 07:12:58) [GCC 9.1.0]
```


##### ADDITIONAL INFORMATION
None

[k8s-doc]: https://kubernetes.io/docs/concepts/services-networking/service/#externalname
