### PR TITLE
Fix DC container image patch

### DIFF
--- a/files/project_export.sh
+++ b/files/project_export.sh
@@ -121,7 +121,9 @@ dcs(){
         echo "Patching DC..."
         OLD_IMAGE=$(cat ${PROJECT}/dc_${dc}.json | jq --arg cname ${container} -r '.spec.template.spec.containers[] | select(.name == $cname)| .image')
         NEW_IMAGE=$(cat ${PROJECT}/dc_${dc}.json | jq -r '.spec.triggers[] | select(.type == "ImageChange") .imageChangeParams.from.name // empty')
-        sed -e "s#$OLD_IMAGE#$NEW_IMAGE#g" ${PROJECT}/dc_${dc}.json >> ${PROJECT}/dc_${dc}_patched.json
+        if [ -n "$OLD_IMAGE" -o -n "$NEW_IMAGE" ]; then
+          sed -e "s#$OLD_IMAGE#$NEW_IMAGE#g" ${PROJECT}/dc_${dc}.json >> ${PROJECT}/dc_${dc}_patched.json
+        fi
       done
     fi
   done


### PR DESCRIPTION
##### SUMMARY
The project exporter applies container image names from ImageChange triggers to the container configuration of DeploymentConfigs. However, this fails if the ImageChange trigger references an inexistent container, causing the entire backup to fail.

This fix only applies the patch, if both the old and new image names could be successfully extracted from the DeploymentConfig

##### ISSUE TYPE
 - Bugfix Pull Request

