### PR TITLE
Fix DeploymentConfig patch with multiple ImageChange triggers

### DIFF
--- a/files/project_export.sh
+++ b/files/project_export.sh
@@ -120,7 +120,7 @@ dcs(){
       # Iterate over the ImageChange triggers and attempt to apply the images referenced there to the containers the trigger references
       for container in $(cat ${PROJECT}/dc_${dc}.json | jq -r '.spec.triggers[] | select(.type == "ImageChange") .imageChangeParams.containerNames[]'); do
         OLD_IMAGE=$(cat ${PROJECT}/dc_${dc}.json | jq --arg cname ${container} -r '.spec.template.spec.containers[] | select(.name == $cname)| .image')
-        NEW_IMAGE=$(cat ${PROJECT}/dc_${dc}.json | jq -r '.spec.triggers[] | select(.type == "ImageChange") .imageChangeParams.from.name // empty')
+        NEW_IMAGE=$(cat ${PROJECT}/dc_${dc}.json | jq --arg cname ${container} -r '.spec.triggers[] | select(.type == "ImageChange") | select(.imageChangeParams.containerNames | index($cname) ) .imageChangeParams.from.name // empty')
         # Only patch the container image reference if both the old and new image could be read successfully.
         # This would e.g. fail if the ImageChange referenced an inexistent container or an inexistent image.
         if [ -n "$OLD_IMAGE" -a -n "$NEW_IMAGE" ]; then


### PR DESCRIPTION
Fix DeploymentConfig patch in cases where multiple ImageChange triggers are present.

##### SUMMARY
The backup would fail if multiple ImageChange triggers are present in a DeploymentConfig. This PR filters the triggers so that only the correct trigger is taken into account when patching the DeploymentConfig.

##### ISSUE TYPE
 - Bugfix Pull Request
